### PR TITLE
Fix apparent typo in call to eval.

### DIFF
--- a/auth-source-xoauth2.el
+++ b/auth-source-xoauth2.el
@@ -226,7 +226,7 @@ See `auth-source-search' for details on SPEC."
                           (insert-file-contents file)
                           (goto-char (point-min))
                           (read (current-buffer)))
-                        (buffer-string))
+                        t)
                 (error
                  (message "auth-source-xoauth2: %s" (error-message-string err))
                  nil))))


### PR DESCRIPTION
The second arg to `eval' is LEXICAL, which controls the evaluation
context.  Passing (buffer-string) makes little sense, so I'm assuming
this was a typo.  On the assumption that Emacs treats a string as
true, pass `t' instead.