### PR TITLE
Raise parse errors for invalid `auth-source-xoauth2-creds' files.

### DIFF
--- a/auth-source-xoauth2.el
+++ b/auth-source-xoauth2.el
@@ -228,8 +228,8 @@ See `auth-source-search' for details on SPEC."
                           (read (current-buffer)))
                         (buffer-string))
                 (error
-                 (message "auth-source-xoauth2: %s" (error-message-string err))
-                 nil))))
+                 "Error parsing contents of %s: %s"
+                 file (error-message-string err))))))
     (cond
      ((hash-table-p creds)
       (message "Searching hash table for (%S %S %S)" host user port)

--- a/auth-source-xoauth2.el
+++ b/auth-source-xoauth2.el
@@ -229,7 +229,7 @@ See `auth-source-search' for details on SPEC."
                         (buffer-string))
                 (error
                  "Error parsing contents of %s: %s"
-                 file (error-message-string err))))))
+                 file (error-message-string err)))))
     (cond
      ((hash-table-p creds)
       (message "Searching hash table for (%S %S %S)" host user port)


### PR DESCRIPTION
Previously the code was calling `error' incorrectly, apparently a
typo?  The first arg is a format string, but the code was passing
it the result of calling `message' (which has no documented return
value).  It also passed a second nil arg for some reason.  ;-)

The result was that no error was raised, so it took me a while to
figure out that I had a typo in my creds file.