### PR TITLE
Fix flag naming mialignment in documentation and the tool

### DIFF
--- a/auth-source-xoauth2.el
+++ b/auth-source-xoauth2.el
@@ -99,8 +99,8 @@ This should get you all the values but for the refresh token.  For that one:
 
    cd google-oauth
    make
-   ./oauth -client_id <client id from previous steps> \
-           -client_secret <client secret from previous steps>
+   ./oauth -client-id <client id from previous steps> \
+           -client-secret <client secret from previous steps>
 
 4. Visit the URL the tool will print on the console.  The page will ask you
    for the permissions needed to access your Google acount.


### PR DESCRIPTION
During testing of the tool I found out that the flags aren't named the way they're named in the tool.